### PR TITLE
chore: Added inherit as valid state value in f-icon-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.4 (May 25, 2023)
+
+### Improvements
+
+- Added `inherit` as valid `state` value in `f-icon-button`
+
+
 ## 1.3.3 (Feb 8, 2023)
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flow-intellisense-vscode",
   "displayName": "Flow Intellisense for flow design system",
   "description": "flow library intellisense for vscode [*.vue, *.html]",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "publisher": "dev-vikas",
   "repository": {
     "type": "git",

--- a/src/config/elements/f-icon-button.json
+++ b/src/config/elements/f-icon-button.json
@@ -76,6 +76,9 @@
           },
           "neutral": {
             "description": "Actions with little prominence"
+          },
+          "inherit": {
+            "description": "Inherits the parent state"
           }
         }
       },


### PR DESCRIPTION
### Checklist for raising a PR
- [ ] All necessary unit tests added.
- [ ] `config` folder is updated as per latest `@cldcvr/flow-*` versions. 
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?


### Describe your PR
![image](https://github.com/cldcvr/flow-intellisense-vscode/assets/39631861/43f20d22-2c77-45c4-84e0-e1169320ce0e)

- Currently, the docs dont show "inherit" as a valid state, but the flow type does.
- Added inherit as valid state value in f-icon-button. 

### Add additional question here
- [ ] `Yes`
- [ ] `No`
- [ ] `NA`