### PR TITLE
chore: Added inherit as valid state value in f-icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
+# Changelog
+
+## 1.3.3 (Feb 8, 2023)
+
+### Improvements
+
+- Added `visible` as an additional allowed value to `overflow` prop in `f-div`
+
+
 ## [1.0.0]
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.4 (May 25, 2023)
+
+### Improvements
+
+- Added `inherit` as valid `state` value in `f-icon-button`
+
+
 ## 1.3.3 (Feb 8, 2023)
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flow-intellisense-vscode",
   "displayName": "Flow Intellisense for flow design system",
   "description": "flow library intellisense for vscode [*.vue, *.html]",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "publisher": "dev-vikas",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flow-intellisense-vscode",
   "displayName": "Flow Intellisense for flow design system",
   "description": "flow library intellisense for vscode [*.vue, *.html]",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "publisher": "dev-vikas",
   "repository": {
     "type": "git",

--- a/src/config/elements/f-div.json
+++ b/src/config/elements/f-div.json
@@ -273,6 +273,9 @@
           },
           "hidden": {
             "description": "Hide elements that overflow the width of height."
+          },
+          "visible": {
+            "description": "Allows children contents to overflow. Sets both the overflow-x and overflow-y to visible."
           }
         }
       },

--- a/src/config/elements/f-icon-button.json
+++ b/src/config/elements/f-icon-button.json
@@ -76,6 +76,9 @@
           },
           "neutral": {
             "description": "Actions with little prominence"
+          },
+          "inherit": {
+            "description": "Inherits the parent state"
           }
         }
       },


### PR DESCRIPTION
### Checklist for raising a PR
- [ ] All necessary unit tests added.
- [ ] `config` folder is updated as per latest `@cldcvr/flow-*` versions. 
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?


### Describe your PR
Fixes incorrect VS Code type hint

![image](https://github.com/cldcvr/flow-intellisense-vscode/assets/39631861/09b8ebee-0035-4513-9991-9a5fe4d39f00)

inherit is a valid value for state

![image](https://github.com/cldcvr/flow-intellisense-vscode/assets/39631861/69340a6d-e726-4ef2-98eb-9f53e7de4688)


### Add additional question here
- [ ] `Yes`
- [ ] `No`
- [ ] `NA`